### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Obsidian MCP Server
 
+[![smithery badge](https://smithery.ai/badge/obsidian-mcp)](https://smithery.ai/server/obsidian-mcp)
+
 An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that enables AI assistants to interact with Obsidian vaults, providing tools for reading, creating, editing and managing notes and tags.
 
 ## Warning!!!
@@ -21,6 +23,16 @@ This MCP has read and write access (if you allow it). Please. PLEASE backup your
 - An Obsidian vault
 
 ## Install
+
+### Installing via Smithery
+
+To install Obsidian for Claude Desktop automatically via [Smithery](https://smithery.ai/server/obsidian-mcp):
+
+```bash
+npx -y @smithery/cli install obsidian-mcp --client claude
+```
+
+### Installing Manually
 Add to your Claude Desktop configuration:
 
 - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Obsidian for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/obsidian-mcp

Let me know if any tweaks have to be made!