### PR TITLE
fix: Support Unicode characters in vault names (including Korean)

### DIFF
--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -424,14 +424,14 @@ export function safeJoinPath(vaultPath: string, ...segments: string[]): string {
 
 /**
  * Sanitizes a vault name to be filesystem-safe
+ * Preserves Unicode characters (including Korean, Japanese, Chinese, etc.)
  * @param name - The raw vault name
  * @returns The sanitized vault name
  */
 export function sanitizeVaultName(name: string): string {
   return name
-    .toLowerCase()
-    // Replace spaces and special characters with hyphens
-    .replace(/[^a-z0-9]+/g, '-')
+    // Replace problematic filesystem characters with hyphens (keep Unicode letters/numbers)
+    .replace(/[\s<>:"/\\|?*\x00-\x1f]+/g, '-')
     // Remove leading/trailing hyphens
     .replace(/^-+|-+$/g, '')
     // Ensure name isn't empty


### PR DESCRIPTION
## Summary
- Fix `sanitizeVaultName` function to preserve Unicode characters (Korean, Japanese, Chinese, etc.)
- Previously, all non-ASCII vault names were converted to "unnamed-vault"
- Now only filesystem-problematic characters are replaced with hyphens

## Problem
The original regex `/[^a-z0-9]+/g` stripped all Unicode characters:

```typescript
// Before: "한글볼트" → "unnamed-vault"
// Before: "日本語" → "unnamed-vault"
// Before: "中文" → "unnamed-vault"
```

## Solution
Changed to only replace filesystem-unsafe characters:

```typescript
// After: "한글볼트" → "한글볼트" ✓
// After: "日本語" → "日本語" ✓
// After: "My Notes" → "My-Notes" ✓
```

## Changes
- `src/utils/path.ts`: Modified `sanitizeVaultName` function
  - Changed regex from `/[^a-z0-9]+/g` to `/[\s<>:"/\\|?*\x00-\x1f]+/g`
  - Removed `.toLowerCase()` to preserve original casing
  - Only replaces: spaces, `<>:"/\|?*`, and control characters

## Test Plan
- [x] Tested with Korean vault name ("한글볼트테스트")
- [x] Tested with Korean filename search
- [x] Tested with Korean content search
- [x] Tested with Korean file reading
- [x] Verified English vault names still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)